### PR TITLE
Check for internet connection before attempting update

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
 >
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <application
         android:fullBackupContent="true"

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -59,4 +59,5 @@
     <string name="theme_dark">Koyu</string>
     <string name="theme_orange">Turuncu</string>
     <string name="content_description_app_icon">Uygulama simgesi</string>
+    <string name="update_check_failed_no_internet">*Update check failed - No internet connection*</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,5 +59,6 @@
     <string name="theme_dark">Dark Droid</string>
     <string name="theme_orange">Orange Juice</string>
     <string name="content_description_app_icon">App Icon</string>
+    <string name="update_check_failed_no_internet">Update check failed - No internet connection</string>
 </resources>
 


### PR DESCRIPTION
Rather than attempting to make a request and catching the inevitable timeout or other exception, this way checks beforehand to see if there is an internet connection or not.

This does, however, require a new permission in the manifest.

If this is acceptable, we can easily add a check for the connection type, and thus add a setting for only checking for certain network types. (ie. only check on wifi, not when using data connection)
We could also start monitoring for network changes, thus allowing for the rescheduling of updates if the person doesn't have an internet connection when the scheduled update is attempted.