### PR TITLE
Update yeriomin:play-store-api to latest 0.29 release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     compile "com.squareup:otto:1.3.8"
     compile "com.google.code.gson:gson:2.8.0"
     compile "com.squareup.okhttp3:okhttp:3.8.0"
-    compile "com.github.yeriomin:play-store-api:0.18"
+    compile "com.github.yeriomin:play-store-api:0.29"
     compile "eu.chainfire:libsuperuser:1.0.0.201704021214"
     compile "uy.kohesive.injekt:injekt-core:1.16.1"
 


### PR DESCRIPTION
Mainly due to ttl issues:
`Changed auth token generation process. For some reason the old way of token generation now produces a token with a very limited time to live. This version attempts to fix this.`