### PR TITLE
Use "latest release" link provided by GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ It provides similar functionality to an app store, but instead of depending on a
 * App ignore list. Filter updates by architecture. Filter experimental apps. Filter apps by API level. Exclude apps installed by an App Store.
 
 # Download
-* [Stable release (2.0.4)](https://github.com/rumboalla/apkupdater/releases/download/2.0.4/app-release.apk)
-* [Older releases](https://github.com/rumboalla/apkupdater/releases)
+* [Current release](https://github.com/rumboalla/apkupdater/releases/latest)
+* [All releases](https://github.com/rumboalla/apkupdater/releases)
 
 # Translations
 If you want to help with translations, use [![Translate](https://poeditor.com/public/images/logo_small.png)](https://poeditor.com/join/project/NWTNMrPFj8) or send a [Pull Request](https://github.com/rumboalla/apkupdater/pulls)


### PR DESCRIPTION
... which does not allow to point directly to the APK, but displays the downloadable files section of the latest release open, so the APK is the first clickable link on that web page.