### PR TITLE
Shortening the 'Instalovat aplikaci' to just 'Instalovat' because of the short button in Czech

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,77 +1,69 @@
 <resources>
 
-    <string name="app_name" translatable="false">APKUpdater</string>
-    <string name="tab_apps">Apps</string>
-    <string name="tab_search">Search</string>
-    <string name="tab_updates">Updates</string>
-    <string name="tab_settings">Settings</string>
-    <string name="something_went_wrong">"Something went wrong\n\uD83E\uDD26"</string>
-    <string name="ignore_version">Ignore Version</string>
-    <string name="ignore_cd">Ignore App</string>
-    <string name="unignore_cd">Unignore App</string>
-    <string name="refresh_updates">Look for Updates</string>
-    <string name="exclude_system_apps">Exclude System Apps</string>
-    <string name="include_system_apps">Include System Apps</string>
-    <string name="exclude_app_store">Exclude App Store</string>
-    <string name="include_app_store">Include App Store</string>
-    <string name="exclude_disabled_apps">Exclude Disabled Apps</string>
-    <string name="include_disabled_apps">Include Disabled Apps</string>
-    <string name="install_cd">Install App</string>
-    <string name="install_all">Install All</string>
-    <string name="app_cd">App Icon</string>
-    <string name="install_success">%1$s installed.</string>
-    <string name="install_failure">%1$s failed to install.</string>
-    <string name="root_install_not_supported">Root install of this app is not supported.</string>
+    <string name="tab_apps">Aplikace</string>
+    <string name="tab_search">Vyhledávání</string>
+    <string name="tab_updates">Aktualizace</string>
+    <string name="tab_settings">Nastavení</string>
+    <string name="something_went_wrong">"Něco se pokazilo\n\uD83E\uDD26"</string>
+    <string name="ignore_version">Ignorovat verzi</string>
+    <string name="ignore_cd">Ignorovat aplikaci</string>
+    <string name="unignore_cd">Zrušit ignorování aplikace</string>
+    <string name="refresh_updates">Vyhledat aktualizace</string>
+    <string name="exclude_system_apps">Vyjmotu systémové aplikace</string>
+    <string name="include_system_apps">zahrnout systémové aplikace</string>
+    <string name="exclude_app_store">Vyjmout Obchod s aplikacemi</string>
+    <string name="include_app_store">Zahrnout Obchod s aplikacemi</string>
+    <string name="exclude_disabled_apps">Vyjmout zakázané aplikace</string>
+    <string name="include_disabled_apps">Zahrnout zakázané aplikac</string>
+    <string name="install_cd">Instalovat aplikaci</string>
+    <string name="install_all">Instaloat vše</string>
+    <string name="app_cd">Ikona aplikace</string>
+    <string name="install_success">%1$s nainstalováno.</string>
+    <string name="install_failure">%1$s se nepovedla nainstalovat.</string>
+    <string name="root_install_not_supported">Instalace této aplikace pomocí rootu není podporována.</string>
 
     // Settings
-    <string name="settings_experimental_installer">Use Experimental New Installer</string>
-    <string name="settings_portrait_columns">Portrait Columns</string>
-    <string name="settings_landscape_columns">Landscape Columns</string>
-    <string name="play_text_animations">Play Text Animations</string>
-    <string name="settings_sources">Sources</string>
+    <string name="settings_experimental_installer">Použít exprerimentální nový instalátor</string>
+    <string name="settings_portrait_columns">Sloupce v portrétním režimu</string>
+    <string name="settings_landscape_columns">Sloupce v režimu na šířku</string>
+    <string name="play_text_animations">Animace textu Play</string>
+    <string name="settings_sources">Zdroje</string>
     <string name="settings_ui">UI</string>
-    <string name="settings_alarm">Alarm</string>
-    <string name="settings_options">Options</string>
-    <string name="settings_utils">Utils</string>
-    <string name="settings_hour">Alarm Hour</string>
-    <string name="settings_alarm_daily">Daily</string>
-    <string name="settings_alarm_3day">3-Day</string>
-    <string name="settings_alarm_weekly">Weekly</string>
-    <string name="settings_android_tv_ui" translatable="false">Android TV UI</string>
-    <string name="ignore_alpha">Ignore Alpha</string>
-    <string name="ignore_beta">Ignore Beta</string>
-    <string name="ignore_preRelease">Ignore Pre-release</string>
-    <string name="use_safe_stores">Use Safe Stores (Aptoide)</string>
-    <string name="root_install">Root Install</string>
-    <string name="source_apkmirror" translatable="false">ApkMirror</string>
-    <string name="source_fdroid" translatable="false">F-Droid Main</string>
-    <string name="source_izzy" translatable="false">F-Droid Izzy</string>
-    <string name="source_aptoide" translatable="false">Aptoide</string>
-    <string name="source_github" translatable="false">GitHub</string>
-    <string name="source_gitlab" translatable="false">GitLab</string>
-    <string name="source_apkpure" translatable="false">APKPure</string>
-    <string name="source_play" translatable="false">Play</string>
-    <string name="about">About</string>
-    <string name="frequency">Frequency</string>
-    <string name="theme">Theme</string>
-    <string name="theme_system">System</string>
-    <string name="theme_dark">Dark</string>
-    <string name="theme_light">Light</string>
-    <string name="about_github">Get the source code, report bugs, request new features and add translations.</string>
-    <string name="about_donate">If you like the app, consider donating to a worthy cause.</string>
-    <string name="copy_to_clipboard">Copy to clipboard</string>
-    <string name="copy_app_list">Copy App List</string>
-    <string name="copy_app_logs">Copy App Logs</string>
+    <string name="settings_alarm">Budík</string>
+    <string name="settings_options">Nastavení</string>
+    <string name="settings_utils">Nástroje</string>
+    <string name="settings_hour">Hodina budíku</string>
+    <string name="settings_alarm_daily">Denní</string>
+    <string name="settings_alarm_3day">3denní</string>
+    <string name="settings_alarm_weekly">Týdenní</string>
+
+    <string name="ignore_alpha">Ignorovat Alpha</string>
+    <string name="ignore_beta">Ignorovat Beta</string>
+    <string name="ignore_preRelease">Ignorovat předběžná vydání</string>
+    <string name="use_safe_stores">Použít bezpečný obchod (Aptoide)</string>
+    <string name="root_install">Root instalace</string>
+
+    <string name="about">O nás</string>
+    <string name="frequency">Frekvence</string>
+    <string name="theme">Motiv</string>
+    <string name="theme_system">Systémový</string>
+    <string name="theme_dark">Tmavý</string>
+    <string name="theme_light">Světlý</string>
+    <string name="about_github">Získejte zdrojový kód, nahlaste chyby, požádejte o nové funkce a přidejte překlady.</string>
+    <string name="about_donate">Pokud se vám aplikace líbí, zvažte dar na dobrou věc.</string>
+    <string name="copy_to_clipboard">Kopírovat do schránky</string>
+    <string name="copy_app_list">Kopírovat seznam aplikací</string>
+    <string name="copy_app_logs">Kopírovat logy aplikací</string>
 
     // Notifications
-    <string name="notification_channel_name">Updates</string>
-    <string name="notification_channel_description">Channel for update notifications.</string>
-    <string name="notification_channel_id" translatable="false">updateChannel</string>
-    <string name="notification_update_title">Updates</string>
+    <string name="notification_channel_name">Aktualizace</string>
+    <string name="notification_channel_description">Kanál pro notifikace o aktualizacích</string>
+
+    <string name="notification_update_title">Aktualizace</string>
     <plurals name="notification_update_description">
-        <item quantity="zero">No updates found.</item>
-        <item quantity="one">Found %1$d update.</item>
-        <item quantity="other">Found %1$d updates.</item>
+        <item quantity="zero">Žádné aktualizace nenalezeny.</item>
+        <item quantity="one">Nalezena %1$d aktualizace.</item>
+        <item quantity="other">Nalezeno %1$d aktualizací.</item>
     </plurals>
 
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -15,7 +15,7 @@
     <string name="include_app_store">Zahrnout Obchod s aplikacemi</string>
     <string name="exclude_disabled_apps">Vyjmout zakázané aplikace</string>
     <string name="include_disabled_apps">Zahrnout zakázané aplikac</string>
-    <string name="install_cd">Instalovat aplikaci</string>
+    <string name="install_cd">Instalovat</string>
     <string name="install_all">Instaloat vše</string>
     <string name="app_cd">Ikona aplikace</string>
     <string name="install_success">%1$s nainstalováno.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -9,8 +9,8 @@
     <string name="ignore_cd">Ignorovat aplikaci</string>
     <string name="unignore_cd">Zrušit ignorování aplikace</string>
     <string name="refresh_updates">Vyhledat aktualizace</string>
-    <string name="exclude_system_apps">Vyjmotu systémové aplikace</string>
-    <string name="include_system_apps">zahrnout systémové aplikace</string>
+    <string name="exclude_system_apps">Vyjmout systémové aplikace</string>
+    <string name="include_system_apps">Zahrnout systémové aplikace</string>
     <string name="exclude_app_store">Vyjmout Obchod s aplikacemi</string>
     <string name="include_app_store">Zahrnout Obchod s aplikacemi</string>
     <string name="exclude_disabled_apps">Vyjmout zakázané aplikace</string>
@@ -19,7 +19,7 @@
     <string name="install_all">Instaloat vše</string>
     <string name="app_cd">Ikona aplikace</string>
     <string name="install_success">%1$s nainstalováno.</string>
-    <string name="install_failure">%1$s se nepovedla nainstalovat.</string>
+    <string name="install_failure">%1$s se nepovedlo nainstalovat.</string>
     <string name="root_install_not_supported">Instalace této aplikace pomocí rootu není podporována.</string>
 
     // Settings

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,0 +1,77 @@
+<resources>
+
+    <string name="app_name" translatable="false">APKUpdater</string>
+    <string name="tab_apps">Apps</string>
+    <string name="tab_search">Search</string>
+    <string name="tab_updates">Updates</string>
+    <string name="tab_settings">Settings</string>
+    <string name="something_went_wrong">"Something went wrong\n\uD83E\uDD26"</string>
+    <string name="ignore_version">Ignore Version</string>
+    <string name="ignore_cd">Ignore App</string>
+    <string name="unignore_cd">Unignore App</string>
+    <string name="refresh_updates">Look for Updates</string>
+    <string name="exclude_system_apps">Exclude System Apps</string>
+    <string name="include_system_apps">Include System Apps</string>
+    <string name="exclude_app_store">Exclude App Store</string>
+    <string name="include_app_store">Include App Store</string>
+    <string name="exclude_disabled_apps">Exclude Disabled Apps</string>
+    <string name="include_disabled_apps">Include Disabled Apps</string>
+    <string name="install_cd">Install App</string>
+    <string name="install_all">Install All</string>
+    <string name="app_cd">App Icon</string>
+    <string name="install_success">%1$s installed.</string>
+    <string name="install_failure">%1$s failed to install.</string>
+    <string name="root_install_not_supported">Root install of this app is not supported.</string>
+
+    // Settings
+    <string name="settings_experimental_installer">Use Experimental New Installer</string>
+    <string name="settings_portrait_columns">Portrait Columns</string>
+    <string name="settings_landscape_columns">Landscape Columns</string>
+    <string name="play_text_animations">Play Text Animations</string>
+    <string name="settings_sources">Sources</string>
+    <string name="settings_ui">UI</string>
+    <string name="settings_alarm">Alarm</string>
+    <string name="settings_options">Options</string>
+    <string name="settings_utils">Utils</string>
+    <string name="settings_hour">Alarm Hour</string>
+    <string name="settings_alarm_daily">Daily</string>
+    <string name="settings_alarm_3day">3-Day</string>
+    <string name="settings_alarm_weekly">Weekly</string>
+    <string name="settings_android_tv_ui" translatable="false">Android TV UI</string>
+    <string name="ignore_alpha">Ignore Alpha</string>
+    <string name="ignore_beta">Ignore Beta</string>
+    <string name="ignore_preRelease">Ignore Pre-release</string>
+    <string name="use_safe_stores">Use Safe Stores (Aptoide)</string>
+    <string name="root_install">Root Install</string>
+    <string name="source_apkmirror" translatable="false">ApkMirror</string>
+    <string name="source_fdroid" translatable="false">F-Droid Main</string>
+    <string name="source_izzy" translatable="false">F-Droid Izzy</string>
+    <string name="source_aptoide" translatable="false">Aptoide</string>
+    <string name="source_github" translatable="false">GitHub</string>
+    <string name="source_gitlab" translatable="false">GitLab</string>
+    <string name="source_apkpure" translatable="false">APKPure</string>
+    <string name="source_play" translatable="false">Play</string>
+    <string name="about">About</string>
+    <string name="frequency">Frequency</string>
+    <string name="theme">Theme</string>
+    <string name="theme_system">System</string>
+    <string name="theme_dark">Dark</string>
+    <string name="theme_light">Light</string>
+    <string name="about_github">Get the source code, report bugs, request new features and add translations.</string>
+    <string name="about_donate">If you like the app, consider donating to a worthy cause.</string>
+    <string name="copy_to_clipboard">Copy to clipboard</string>
+    <string name="copy_app_list">Copy App List</string>
+    <string name="copy_app_logs">Copy App Logs</string>
+
+    // Notifications
+    <string name="notification_channel_name">Updates</string>
+    <string name="notification_channel_description">Channel for update notifications.</string>
+    <string name="notification_channel_id" translatable="false">updateChannel</string>
+    <string name="notification_update_title">Updates</string>
+    <plurals name="notification_update_description">
+        <item quantity="zero">No updates found.</item>
+        <item quantity="one">Found %1$d update.</item>
+        <item quantity="other">Found %1$d updates.</item>
+    </plurals>
+
+</resources>


### PR DESCRIPTION
Shorten 'Instalovat aplikaci' to 'Instalovat' because of the short button. With the Instalovat aplikaci, button has two lines instead of one. Eventually you can widen the button? 