### PR TITLE
Fix installation state reset on refresh and prevent duplicate downloads

### DIFF
--- a/app/src/main/kotlin/com/apkupdater/viewmodel/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/apkupdater/viewmodel/SearchViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 
 class SearchViewModel(
@@ -98,20 +99,26 @@ class SearchViewModel(
     }
 
     override fun downloadAndRootInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
-        mutex.withLock {
-            if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@launch
+        val shouldInstall = mutex.withLock {
+            if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@withLock false
             state.value = SearchUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
+            return@withLock true
         }
-        downloadAndRootInstall(update.id, update.link)
+        if (shouldInstall) {
+            downloadAndRootInstall(update.id, update.link)
+        }
     }
 
     override fun downloadAndInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
-        mutex.withLock {
-            if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@launch
-            if(!installer.checkPermission()) return@launch
+        val shouldInstall = mutex.withLock {
+            if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@withLock false
+            if(!installer.checkPermission()) return@withLock false
             state.value = SearchUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
+            return@withLock true
         }
-        downloadAndInstall(update.id, update.packageName, update.link)
+        if (shouldInstall) {
+            downloadAndInstall(update.id, update.packageName, update.link)
+        }
     }
 
     override fun sendInstallSnack(log: AppInstallStatus) {

--- a/app/src/main/kotlin/com/apkupdater/viewmodel/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/apkupdater/viewmodel/SearchViewModel.kt
@@ -44,7 +44,9 @@ class SearchViewModel(
     init {
         subscribeToInstallStatus()
         subscribeToInstallProgress { progress ->
-            state.value = SearchUiState.Success(state.value.mutableUpdates().setProgress(progress))
+            state.value.onSuccess {
+                state.value = SearchUiState.Success(it.updates.toMutableList().setProgress(progress))
+            }
         }
     }
 
@@ -60,8 +62,18 @@ class SearchViewModel(
         badger.changeSearchBadge("")
         searchRepository.search(text).collect {
             it.onSuccess { apps ->
-                state.value = SearchUiState.Success(apps)
-                badger.changeSearchBadge(apps.size.toString())
+                val currentUpdates = state.value.updates()
+                val merged = apps.map { newUpdate ->
+                    currentUpdates.find { it.id == newUpdate.id }?.let { oldUpdate ->
+                        newUpdate.copy(
+                            isInstalling = oldUpdate.isInstalling,
+                            progress = oldUpdate.progress,
+                            total = oldUpdate.total
+                        )
+                    } ?: newUpdate
+                }
+                state.value = SearchUiState.Success(merged)
+                badger.changeSearchBadge(merged.size.toString())
             }.onFailure {
                 badger.changeSearchBadge("!")
                 state.value = SearchUiState.Error
@@ -70,23 +82,29 @@ class SearchViewModel(
     }
 
     override fun cancelInstall(id: Int) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
-        state.value = SearchUiState.Success(state.value.mutableUpdates().setIsInstalling(id, false))
+        state.value.onSuccess {
+            state.value = SearchUiState.Success(it.updates.toMutableList().setIsInstalling(id, false))
+        }
         installer.finish()
     }
 
     override fun finishInstall(id: Int) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
-        val updates = state.value.mutableUpdates().removeId(id)
-        state.value = SearchUiState.Success(updates)
-        badger.changeSearchBadge(updates.size.toString())
+        state.value.onSuccess {
+            val updates = it.updates.toMutableList().removeId(id)
+            state.value = SearchUiState.Success(updates)
+            badger.changeSearchBadge(updates.size.toString())
+        }
         installer.finish()
     }
 
-    override fun downloadAndRootInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
+    override fun downloadAndRootInstall(update: AppUpdate) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
+        if (state.value.updates().any { it.id == update.id && it.isInstalling }) return@launchWithMutex
         state.value = SearchUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
         downloadAndRootInstall(update.id, update.link)
     }
 
-    override fun downloadAndInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
+    override fun downloadAndInstall(update: AppUpdate) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
+        if (state.value.updates().any { it.id == update.id && it.isInstalling }) return@launchWithMutex
         if(installer.checkPermission()) {
             state.value = SearchUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
             downloadAndInstall(update.id, update.packageName, update.link)

--- a/app/src/main/kotlin/com/apkupdater/viewmodel/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/apkupdater/viewmodel/SearchViewModel.kt
@@ -97,18 +97,21 @@ class SearchViewModel(
         installer.finish()
     }
 
-    override fun downloadAndRootInstall(update: AppUpdate) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
-        if (state.value.updates().any { it.id == update.id && it.isInstalling }) return@launchWithMutex
-        state.value = SearchUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
+    override fun downloadAndRootInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
+        mutex.withLock {
+            if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@launch
+            state.value = SearchUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
+        }
         downloadAndRootInstall(update.id, update.link)
     }
 
-    override fun downloadAndInstall(update: AppUpdate) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
-        if (state.value.updates().any { it.id == update.id && it.isInstalling }) return@launchWithMutex
-        if(installer.checkPermission()) {
+    override fun downloadAndInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
+        mutex.withLock {
+            if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@launch
+            if(!installer.checkPermission()) return@launch
             state.value = SearchUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
-            downloadAndInstall(update.id, update.packageName, update.link)
         }
+        downloadAndInstall(update.id, update.packageName, update.link)
     }
 
     override fun sendInstallSnack(log: AppInstallStatus) {

--- a/app/src/main/kotlin/com/apkupdater/viewmodel/UpdatesViewModel.kt
+++ b/app/src/main/kotlin/com/apkupdater/viewmodel/UpdatesViewModel.kt
@@ -43,7 +43,9 @@ class UpdatesViewModel(
 	init {
 		subscribeToInstallStatus()
 		subscribeToInstallProgress { progress ->
-			state.value = UpdatesUiState.Success(state.value.mutableUpdates().setProgress(progress))
+			state.value.onSuccess {
+				state.value = UpdatesUiState.Success(it.updates.toMutableList().setProgress(progress))
+			}
 		}
 	}
 
@@ -73,25 +75,31 @@ class UpdatesViewModel(
 		val ignored = prefs.ignoredVersions.get().toMutableList()
 		if (ignored.contains(id)) ignored.remove(id) else ignored.add(id)
 		prefs.ignoredVersions.put(ignored)
-		setSuccess(state.value.mutableUpdates())
+		setSuccess(state.value.updates())
 	}
 
 	override fun cancelInstall(id: Int) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
-		state.value = UpdatesUiState.Success(state.value.mutableUpdates().setIsInstalling(id, false))
+		state.value.onSuccess {
+			state.value = UpdatesUiState.Success(it.updates.toMutableList().setIsInstalling(id, false))
+		}
 		installer.finish()
 	}
 
 	override fun finishInstall(id: Int) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
-		setSuccess(state.value.mutableUpdates().removeId(id))
+		state.value.onSuccess {
+			setSuccess(it.updates.toMutableList().removeId(id))
+		}
 		installer.finish()
 	}
 
-	override fun downloadAndRootInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
+	override fun downloadAndRootInstall(update: AppUpdate) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
+		if (state.value.updates().any { it.id == update.id && it.isInstalling }) return@launchWithMutex
 		state.value = UpdatesUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
 		downloadAndRootInstall(update.id, update.link)
 	}
 
-	override fun downloadAndInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
+	override fun downloadAndInstall(update: AppUpdate) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
+		if (state.value.updates().any { it.id == update.id && it.isInstalling }) return@launchWithMutex
 		if(installer.checkPermission()) {
 			state.value = UpdatesUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
 			downloadAndInstall(update.id, update.packageName, update.link)
@@ -110,11 +118,23 @@ class UpdatesViewModel(
 	private fun List<AppUpdate>.filterIgnoredVersions(ignoredVersions: List<Int>) = this
 		.filter { !ignoredVersions.contains(it.id) }
 
-	private fun setSuccess(updates: List<AppUpdate>) = updates
-		.filterIgnoredVersions(prefs.ignoredVersions.get())
-		.let {
-			state.value = UpdatesUiState.Success(it)
-			badger.changeUpdatesBadge(it.size.toString())
-		}
+	private fun setSuccess(updates: List<AppUpdate>) {
+		val currentUpdates = state.value.updates()
+		updates
+			.filterIgnoredVersions(prefs.ignoredVersions.get())
+			.map { newUpdate ->
+				currentUpdates.find { it.id == newUpdate.id }?.let { oldUpdate ->
+					newUpdate.copy(
+						isInstalling = oldUpdate.isInstalling,
+						progress = oldUpdate.progress,
+						total = oldUpdate.total
+					)
+				} ?: newUpdate
+			}
+			.let {
+				state.value = UpdatesUiState.Success(it)
+				badger.changeUpdatesBadge(it.size.toString())
+			}
+	}
 
 }

--- a/app/src/main/kotlin/com/apkupdater/viewmodel/UpdatesViewModel.kt
+++ b/app/src/main/kotlin/com/apkupdater/viewmodel/UpdatesViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 
 class UpdatesViewModel(
@@ -62,12 +63,15 @@ class UpdatesViewModel(
 	fun installAll() = viewModelScope.launch(Dispatchers.IO) {
 		if(installer.checkPermission()) {
 			state.value.updates().forEach { update ->
-				mutex.withLock {
-					if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@forEach
+				val shouldInstall = mutex.withLock {
+					if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@withLock false
 					state.value = UpdatesUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
+					return@withLock true
 				}
-				viewModelScope.launch(Dispatchers.IO) {
-					downloadAndInstall(update.id, update.packageName, update.link)
+				if (shouldInstall) {
+					viewModelScope.launch(Dispatchers.IO) {
+						downloadAndInstall(update.id, update.packageName, update.link)
+					}
 				}
 			}
 		}
@@ -95,20 +99,26 @@ class UpdatesViewModel(
 	}
 
 	override fun downloadAndRootInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
-		mutex.withLock {
-			if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@launch
+		val shouldInstall = mutex.withLock {
+			if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@withLock false
 			state.value = UpdatesUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
+			return@withLock true
 		}
-		downloadAndRootInstall(update.id, update.link)
+		if (shouldInstall) {
+			downloadAndRootInstall(update.id, update.link)
+		}
 	}
 
 	override fun downloadAndInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
-		mutex.withLock {
-			if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@launch
-			if(!installer.checkPermission()) return@launch
+		val shouldInstall = mutex.withLock {
+			if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@withLock false
+			if(!installer.checkPermission()) return@withLock false
 			state.value = UpdatesUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
+			return@withLock true
 		}
-		downloadAndInstall(update.id, update.packageName, update.link)
+		if (shouldInstall) {
+			downloadAndInstall(update.id, update.packageName, update.link)
+		}
 	}
 
 	override fun sendInstallSnack(log: AppInstallStatus) {

--- a/app/src/main/kotlin/com/apkupdater/viewmodel/UpdatesViewModel.kt
+++ b/app/src/main/kotlin/com/apkupdater/viewmodel/UpdatesViewModel.kt
@@ -59,11 +59,13 @@ class UpdatesViewModel(
 		}
 	}
 
-	fun installAll() = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
+	fun installAll() = viewModelScope.launch(Dispatchers.IO) {
 		if(installer.checkPermission()) {
 			state.value.updates().forEach { update ->
-				if (state.value.updates().any { it.id == update.id && it.isInstalling }) return@forEach
-				state.value = UpdatesUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
+				mutex.withLock {
+					if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@forEach
+					state.value = UpdatesUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
+				}
 				viewModelScope.launch(Dispatchers.IO) {
 					downloadAndInstall(update.id, update.packageName, update.link)
 				}
@@ -92,18 +94,21 @@ class UpdatesViewModel(
 		installer.finish()
 	}
 
-	override fun downloadAndRootInstall(update: AppUpdate) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
-		if (state.value.updates().any { it.id == update.id && it.isInstalling }) return@launchWithMutex
-		state.value = UpdatesUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
+	override fun downloadAndRootInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
+		mutex.withLock {
+			if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@launch
+			state.value = UpdatesUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
+		}
 		downloadAndRootInstall(update.id, update.link)
 	}
 
-	override fun downloadAndInstall(update: AppUpdate) = viewModelScope.launchWithMutex(mutex, Dispatchers.IO) {
-		if (state.value.updates().any { it.id == update.id && it.isInstalling }) return@launchWithMutex
-		if(installer.checkPermission()) {
+	override fun downloadAndInstall(update: AppUpdate) = viewModelScope.launch(Dispatchers.IO) {
+		mutex.withLock {
+			if (state.value.updates().any { it.packageName == update.packageName && it.isInstalling }) return@launch
+			if(!installer.checkPermission()) return@launch
 			state.value = UpdatesUiState.Success(state.value.mutableUpdates().setIsInstalling(update.id, true))
-			downloadAndInstall(update.id, update.packageName, update.link)
 		}
+		downloadAndInstall(update.id, update.packageName, update.link)
 	}
 
 	override fun sendInstallSnack(log: AppInstallStatus) {


### PR DESCRIPTION
refreshing the Updates page while an update is downloading brings back the download button, allowing a second (and potentially more) update to start downloading alongside it (#548)

Fixed:
* Pull-to-refresh or searching during an active download no longer resets the UI (keeps the percentage display on supported sources).
* UI no longer freezes when a download starts (refactored mutex to be more granular).

Improved:
* Added guards to prevent starting multiple download tasks for the same package/entry.
* Merged existing installation states when repository data is refreshed.

based on upstream version [0.0.596-ci](https://github.com/rumboalla/apkupdater/releases/tag/0.0.596-ci) ([6e6ef1c](https://github.com/rumboalla/apkupdater/commit/6e6ef1c7a9a55f89f4b1841d5fe74b3359a5aacb))
APK: https://github.com/emberglazee/apkupdater/releases/tag/0.0.6-ci (requires complete reinstall - different signature and older version)