### PR TITLE
Allow toggling root install without pre-granted root

### DIFF
--- a/app/src/main/kotlin/com/apkupdater/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/apkupdater/viewmodel/SettingsViewModel.kt
@@ -14,7 +14,6 @@ import com.apkupdater.util.UpdatesNotification
 import com.apkupdater.worker.UpdatesWorker
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -79,11 +78,7 @@ class SettingsViewModel(
 	}
 
 	fun setRootInstall(b: Boolean) {
-		if (b && Shell.isAppGrantedRoot() == true) {
-			prefs.rootInstall.put(true)
-		} else {
-			prefs.rootInstall.put(false)
-		}
+		prefs.rootInstall.put(b)
 	}
 
 	fun setAlarmFrequency(frequency: Int) {


### PR DESCRIPTION
Removed the restrictive Shell.isAppGrantedRoot() check in SettingsViewModel. This prevents the 'catch-22' where users couldn't enable the toggle because root hadn't been requested yet. Root will now be requested by libsu during the actual installation process.