### PR TITLE
ci: pin actions versions with hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup Java 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'zulu'
         java-version: '17'
@@ -34,7 +34,7 @@ jobs:
       run: echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
 
     - name: Create Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
       if: github.ref == 'refs/heads/3.x'
       with:
         tag_name: 0.0.${{ github.run_number }}-ci


### PR DESCRIPTION
# ci: pin actions versions with hashes

I have pinned the versions of the actions used in the workflows with hashes.

Pinning GitHub Actions to a commit hash is an effective safeguard against supply chain attacks. By referencing a specific and immutable version of an action, you prevent compromised versions from being automatically integrated into your pipelines.

Because I bumped versions of some actions, I checked the breaking changes in the involved actions, and our workflows are not concerned by these breaking changes.

Here is the link to the tags for the actions I've pinned, if you want to check the hashes:
- https://github.com/actions/checkout/releases/tag/v6.0.3
- https://github.com/actions/setup-java/releases/tag/v5.2.0
- https://github.com/softprops/action-gh-release/releases/tag/v3.0.0

Pinning versions requires some maintenance, as you must perform manual upgrades regularly. However, in your case, with workflows that handle secrets (such as `secrets.KEYSTORE` or `secrets.PROPERTIES`), it’s a best practice to avoid trouble.